### PR TITLE
working grpc endpoint, consumer, producer

### DIFF
--- a/cmd/grpc_server/main.go
+++ b/cmd/grpc_server/main.go
@@ -1,0 +1,32 @@
+package grpc_server
+
+import (
+	"log"
+	"net"
+	"os"
+
+	"github.com/Nickadimas79/kafka_testing/pkg/people"
+	peoplePB "github.com/Nickadimas79/kafka_testing/protobufs/people"
+
+	"google.golang.org/grpc"
+)
+
+const gRPCPort = ":8080"
+
+func StartGRPC() {
+	lis, err := net.Listen("tcp", gRPCPort)
+	if err != nil {
+		log.Println("failed to start TCP listener")
+		os.Exit(1)
+	}
+
+	grpcServer := grpc.NewServer()
+	peopleServ := people.Server{}
+
+	peoplePB.RegisterPeopleServer(grpcServer, &peopleServ)
+
+	if err := grpcServer.Serve(lis); err != nil {
+		log.Println("failed to start gRPC server")
+		os.Exit(1)
+	}
+}

--- a/kafka/ccloud/get_config.go
+++ b/kafka/ccloud/get_config.go
@@ -3,7 +3,9 @@ package ccloud
 import (
 	"bufio"
 	"fmt"
+	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
@@ -37,4 +39,53 @@ func ReadConfig(configFile string) kafka.ConfigMap {
 
 	return m
 
+}
+
+func ProducerConfig() kafka.ConfigMap {
+	var conf kafka.ConfigMap
+
+	env := os.Getenv("ENV")
+	if env == "" {
+		// For local development purposes using locally held "properties" file.
+		log.Println("defaulting Producer to Rando Caltestian Kafka")
+
+		p, _ := os.Getwd()
+		conf = ReadConfig(filepath.Join(p + "/kafka/producer/properties"))
+	} else {
+		conf = kafka.ConfigMap{
+			"bootstrap.servers": os.Getenv("BOOT_STRAP_SERVER"),
+			"security.protocol": os.Getenv("SECURITY_PROTOCOL"),
+			"sasl.mechanisms":   os.Getenv("SASL_MECHANISMS"),
+			"sasl.username":     os.Getenv("SASL_USERNAME"),
+			"sasl.password":     os.Getenv("SASL_PASSWORD"),
+			"acks":              os.Getenv("ACKS"),
+		}
+	}
+
+	return conf
+}
+
+func ConsumerConfig() kafka.ConfigMap {
+	var conf kafka.ConfigMap
+
+	env := os.Getenv("ENV")
+	if env == "" {
+		// For local development purposes using locally held "properties" file.
+		log.Println("defaulting Consumer to Rando Caltestian Kafka")
+
+		p, _ := os.Getwd()
+		conf = ReadConfig(filepath.Join(p + "/kafka/consumer/properties"))
+	} else {
+		conf = kafka.ConfigMap{
+			"bootstrap.servers":  os.Getenv("BOOT_STRAP_SERVER"),
+			"security.protocol":  os.Getenv("SECURITY_PROTOCOL"),
+			"sasl.mechanisms":    os.Getenv("SASL_MECHANISMS"),
+			"sasl.username":      os.Getenv("SASL_USERNAME"),
+			"sasl.password":      os.Getenv("SASL_PASSWORD"),
+			"enable.auto.commit": true,
+			"auto.offset.reset":  "earliest",
+		}
+	}
+
+	return conf
 }

--- a/pkg/people/main.go
+++ b/pkg/people/main.go
@@ -2,6 +2,7 @@ package people
 
 import (
 	"context"
+
 	pb "github.com/Nickadimas79/kafka_testing/protobufs/people"
 )
 


### PR DESCRIPTION
Added fully working independent Producer and Consumer along with proper "teardown" capabilities to remove deadlock problems from before. Also put gRPC server on its own independent thread as well.